### PR TITLE
Release notes for Plugin Pipeline Example 0.1.0-beta14

### DIFF
--- a/source/releasenotes/2024-11-20-plugin-pipeline-example-0-1-0-beta14.md
+++ b/source/releasenotes/2024-11-20-plugin-pipeline-example-0-1-0-beta14.md
@@ -1,0 +1,9 @@
+---
+title: Plugin Pipeline Example 0.1.0-beta14 now available
+published_date: "2024-11-20"
+categories: [wordpress,plugin]
+---
+
+The latest version of Plugin Pipeline Example, [0.1.0-beta14](https://github.com/jazzsequence/plugin-pipeline-example/releases/tag/0.1.0-beta14), is available as of November, 20, 2024.
+
+**Full Changelog**: https://github.com/jazzsequence/plugin-pipeline-example/compare/0.1.0-beta13...0.1.0-beta14


### PR DESCRIPTION
* **[Release Notes](https://docs.pantheon.io/releasenotes)** - Adds a release note for Plugin Pipeline Example [0.1.0-beta14](https://github.com/jazzsequence/plugin-pipeline-example/releases/tag/0.1.0-beta14).