### PR TITLE
Release note for Plugin Pipeline Example 0.3.10-beta5

### DIFF
--- a/source/releasenotes/2024-11-21-plugin-pipeline-example-0-3-10-beta5.md
+++ b/source/releasenotes/2024-11-21-plugin-pipeline-example-0-3-10-beta5.md
@@ -1,0 +1,24 @@
+---
+title: "Plugin Pipeline Example 0.3.10-beta5 now available"
+published_date: "2024-11-21"
+categories: [wordpress,plugins]
+---
+
+The latest version of Plugin Pipeline Example, [0.3.10-beta5](https://github.com/pantheon-systems/plugin-pipeline-example/releases/tag/0.3.10-beta5), is available as of November, 21, 2024.
+
+## What's Changed
+* Bump ip from 2.0.0 to 2.0.1 by @dependabot in https://github.com/pantheon-systems/plugin-pipeline-example/pull/74
+* Make update dev step conditional by @jazzsequence in https://github.com/pantheon-systems/plugin-pipeline-example/pull/77
+* Bump tar from 6.1.15 to 6.2.1 by @dependabot in https://github.com/pantheon-systems/plugin-pipeline-example/pull/78
+* Bump braces from 3.0.2 to 3.0.3 by @dependabot in https://github.com/pantheon-systems/plugin-pipeline-example/pull/79
+* [SITE-1547] Update CODEOWNERS for new team names by @greg-1-anderson in https://github.com/pantheon-systems/plugin-pipeline-example/pull/80
+* [SITE-1547] Add catalog-info.yml by @namespacebrian in https://github.com/pantheon-systems/plugin-pipeline-example/pull/82
+* Rename catalog-info.yml to catalog-info.yaml by @namespacebrian in https://github.com/pantheon-systems/plugin-pipeline-example/pull/83
+* add validate plugin version action by @jazzsequence in https://github.com/pantheon-systems/plugin-pipeline-example/pull/85
+* Update Tested Up To version to 6.6.2 by @github-actions in https://github.com/pantheon-systems/plugin-pipeline-example/pull/88
+
+## New Contributors
+* @greg-1-anderson made their first contribution in https://github.com/pantheon-systems/plugin-pipeline-example/pull/80
+* @namespacebrian made their first contribution in https://github.com/pantheon-systems/plugin-pipeline-example/pull/82
+
+**Full Changelog**: https://github.com/pantheon-systems/plugin-pipeline-example/compare/0.3.9...0.3.10-beta5


### PR DESCRIPTION
**[Release Notes](https://docs.pantheon.io/releasenotes)** - Adds a release note for [Plugin Pipeline Example 0.3.10-beta5](https://github.com/pantheon-systems/plugin-pipeline-example/releases/tag/0.3.10-beta5).